### PR TITLE
Implement local run using Docker

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,21 @@
 # VendHound
 Convention Dealer's Room tool to run juries.  Successor to the Dealer's Room THING
+
+## Quick Start with Docker
+
+To run VendHound using Docker:
+
+1. Navigate to the `app/` directory
+2. Create a `.env.local` file with your configuration (see `README.docker.md` for details)
+3. Build and start the containers:
+   ```bash
+   cd app
+   docker-compose up -d --build
+   ```
+4. Run database migrations:
+   ```bash
+   docker-compose exec app php bin/console doctrine:migrations:migrate
+   ```
+5. Access the application at http://localhost:8080
+
+For detailed Docker setup instructions, see [app/README.docker.md](app/README.docker.md)

--- a/app/.dockerignore
+++ b/app/.dockerignore
@@ -1,0 +1,11 @@
+.git
+.gitignore
+var/cache/*
+var/log/*
+vendor/
+.env.local
+.env.local.php
+.env.*.local
+tests/
+.phpunit.cache/
+

--- a/app/Dockerfile
+++ b/app/Dockerfile
@@ -1,0 +1,67 @@
+FROM php:8.2-apache
+
+# Install system dependencies
+RUN apt-get update && apt-get install -y \
+    git \
+    curl \
+    libpng-dev \
+    libonig-dev \
+    libxml2-dev \
+    libzip-dev \
+    libicu-dev \
+    zip \
+    unzip \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install PHP extensions
+RUN docker-php-ext-install \
+    pdo \
+    pdo_mysql \
+    mysqli \
+    mbstring \
+    exif \
+    pcntl \
+    bcmath \
+    zip \
+    intl
+
+# Install Composer
+COPY --from=composer:latest /usr/bin/composer /usr/bin/composer
+
+# Set working directory
+WORKDIR /var/www/html
+
+# Copy application files
+COPY . /var/www/html
+
+# Install PHP dependencies
+RUN composer install --no-interaction --optimize-autoloader --no-dev || true
+
+# Install JavaScript dependencies via importmap
+RUN php bin/console importmap:install || true
+
+# Set proper permissions
+RUN chown -R www-data:www-data /var/www/html \
+    && chmod -R 755 /var/www/html
+
+# Enable Apache modules
+RUN a2enmod rewrite
+
+# Configure Apache DocumentRoot to point to public directory
+ENV APACHE_DOCUMENT_ROOT=/var/www/html/public
+RUN sed -ri -e 's!/var/www/html!${APACHE_DOCUMENT_ROOT}!g' /etc/apache2/sites-available/*.conf
+RUN sed -ri -e 's!/var/www/!${APACHE_DOCUMENT_ROOT}!g' /etc/apache2/apache2.conf /etc/apache2/conf-available/*.conf
+
+# Enable .htaccess overrides
+RUN sed -i '/<Directory \/var\/www\/>/,/<\/Directory>/ s/AllowOverride None/AllowOverride All/' /etc/apache2/apache2.conf
+
+# Create necessary Symfony directories with proper permissions
+RUN mkdir -p var/cache var/log \
+    && chown -R www-data:www-data var \
+    && chmod -R 775 var
+
+EXPOSE 80
+
+CMD ["apache2-foreground"]
+

--- a/app/README.docker.md
+++ b/app/README.docker.md
@@ -18,14 +18,14 @@ APP_ENV=dev
 APP_SECRET=ChangeThisSecretKeyInProduction
 
 # Database configuration for Docker
-DATABASE_URL="mysql://app:!ChangeMe!@database:3306/app?serverVersion=8.0&charset=utf8mb4"
+DATABASE_URL="mysql://app:!ChangeMe!@database:3306/app?serverVersion=11.2.6-MariaDB&charset=utf8mb4"
 
-# MySQL configuration
-MYSQL_DATABASE=app
-MYSQL_USER=app
-MYSQL_PASSWORD=!ChangeMe!
-MYSQL_ROOT_PASSWORD=!ChangeMe!
-MYSQL_VERSION=8.0
+# MariaDB configuration
+MARIADB_DATABASE=app
+MARIADB_USER=app
+MARIADB_PASSWORD=!ChangeMe!
+MARIADB_ROOT_PASSWORD=!ChangeMe!
+MARIADB_VERSION=11.2
 
 # Mailer configuration
 MAILER_DSN=smtp://mailer:1025
@@ -46,7 +46,7 @@ docker-compose up -d --build
 
 This will:
 - Build the PHP application container
-- Start the MySQL database
+- Start the MariaDB database
 - Start the Mailpit mail server (for development)
 
 ### 3. Install Dependencies
@@ -67,7 +67,7 @@ docker-compose exec app php bin/console doctrine:migrations:migrate
 
 - **Application:** http://localhost:8080
 - **Mailpit UI:** http://localhost:8025 (to view emails sent during development)
-- **MySQL:** localhost:3306
+- **MariaDB:** localhost:3306
 
 ## Useful Commands
 
@@ -104,7 +104,7 @@ docker-compose exec app php bin/console cache:clear
 ## Services
 
 - **app**: PHP 8.2 with Apache running the Symfony application (port 8080)
-- **database**: MySQL 8.0 (port 3306)
+- **database**: MariaDB 11.2 (port 3306)
 - **mailer**: Mailpit for email testing (ports 1025/8025)
 
 ## Troubleshooting

--- a/app/README.docker.md
+++ b/app/README.docker.md
@@ -1,0 +1,136 @@
+# Docker Setup for VendHound
+
+This document describes how to run the VendHound application using Docker.
+
+## Prerequisites
+
+- Docker
+- Docker Compose
+
+## Getting Started
+
+### 1. Environment Configuration
+
+Create a `.env.local` file in the `app/` directory with the following content:
+
+```env
+APP_ENV=dev
+APP_SECRET=ChangeThisSecretKeyInProduction
+
+# Database configuration for Docker
+DATABASE_URL="mysql://app:!ChangeMe!@database:3306/app?serverVersion=8.0&charset=utf8mb4"
+
+# MySQL configuration
+MYSQL_DATABASE=app
+MYSQL_USER=app
+MYSQL_PASSWORD=!ChangeMe!
+MYSQL_ROOT_PASSWORD=!ChangeMe!
+MYSQL_VERSION=8.0
+
+# Mailer configuration
+MAILER_DSN=smtp://mailer:1025
+EMAIL_FROM_ADDRESS=noreply@vendhound.local
+EMAIL_FROM_NAME=VendHound
+```
+
+**Note:** Change the `APP_SECRET` and database password in production!
+
+### 2. Build and Start the Containers
+
+Navigate to the `app/` directory and run:
+
+```bash
+cd app
+docker-compose up -d --build
+```
+
+This will:
+- Build the PHP application container
+- Start the MySQL database
+- Start the Mailpit mail server (for development)
+
+### 3. Install Dependencies
+
+If you need to install Composer dependencies inside the container:
+
+```bash
+docker-compose exec app composer install
+```
+
+### 4. Run Database Migrations
+
+```bash
+docker-compose exec app php bin/console doctrine:migrations:migrate
+```
+
+### 5. Access the Application
+
+- **Application:** http://localhost:8080
+- **Mailpit UI:** http://localhost:8025 (to view emails sent during development)
+- **MySQL:** localhost:3306
+
+## Useful Commands
+
+### View logs
+```bash
+docker-compose logs -f app
+```
+
+### Access the app container shell
+```bash
+docker-compose exec app bash
+```
+
+### Stop the containers
+```bash
+docker-compose down
+```
+
+### Stop and remove volumes (WARNING: destroys database data)
+```bash
+docker-compose down -v
+```
+
+### Rebuild containers
+```bash
+docker-compose up -d --build
+```
+
+### Clear Symfony cache
+```bash
+docker-compose exec app php bin/console cache:clear
+```
+
+## Services
+
+- **app**: PHP 8.2 with Apache running the Symfony application (port 8080)
+- **database**: MySQL 8.0 (port 3306)
+- **mailer**: Mailpit for email testing (ports 1025/8025)
+
+## Troubleshooting
+
+### Permission Issues
+
+If you encounter permission issues with var/cache or var/log:
+
+```bash
+docker-compose exec app chown -R www-data:www-data var/
+docker-compose exec app chmod -R 775 var/
+```
+
+### Database Connection Issues
+
+Make sure the database container is healthy before the app starts. Check status:
+
+```bash
+docker-compose ps
+```
+
+### Composer Install Fails
+
+If Composer install fails during build, you can run it manually:
+
+```bash
+docker-compose exec app composer install --no-interaction
+```
+

--- a/app/compose.override.yaml
+++ b/app/compose.override.yaml
@@ -3,16 +3,19 @@ services:
 ###> doctrine/doctrine-bundle ###
   database:
     ports:
-      - "5432"
+      - "3306:3306"
 ###< doctrine/doctrine-bundle ###
 
 ###> symfony/mailer ###
   mailer:
     image: axllent/mailpit
+    container_name: vendhound_mailer
     ports:
-      - "1025"
-      - "8025"
+      - "1025:1025"
+      - "8025:8025"
     environment:
       MP_SMTP_AUTH_ACCEPT_ANY: 1
       MP_SMTP_AUTH_ALLOW_INSECURE: 1
+    networks:
+      - vendhound_network
 ###< symfony/mailer ###

--- a/app/compose.yaml
+++ b/app/compose.yaml
@@ -15,7 +15,7 @@ services:
     environment:
       - APP_ENV=${APP_ENV:-dev}
       - APP_SECRET=${APP_SECRET:-ChangeThisSecretKey}
-      - DATABASE_URL=mysql://${MYSQL_USER:-app}:${MYSQL_PASSWORD:-!ChangeMe!}@database:3306/${MYSQL_DATABASE:-app}?serverVersion=8.0&charset=utf8mb4
+      - DATABASE_URL=mysql://${MARIADB_USER:-app}:${MARIADB_PASSWORD:-!ChangeMe!}@database:3306/${MARIADB_DATABASE:-app}?serverVersion=11.2.6-MariaDB&charset=utf8mb4
       - MAILER_DSN=smtp://mailer:1025
       - EMAIL_FROM_ADDRESS=${EMAIL_FROM_ADDRESS:-noreply@vendhound.local}
       - EMAIL_FROM_NAME=${EMAIL_FROM_NAME:-VendHound}
@@ -27,15 +27,15 @@ services:
 
 ###> doctrine/doctrine-bundle ###
   database:
-    image: mysql:${MYSQL_VERSION:-8.0}
+    image: mariadb:${MARIADB_VERSION:-11.2}
     container_name: vendhound_db
     environment:
-      MYSQL_DATABASE: ${MYSQL_DATABASE:-app}
-      MYSQL_ROOT_PASSWORD: ${MYSQL_ROOT_PASSWORD:-!ChangeMe!}
-      MYSQL_USER: ${MYSQL_USER:-app}
-      MYSQL_PASSWORD: ${MYSQL_PASSWORD:-!ChangeMe!}
+      MARIADB_DATABASE: ${MARIADB_DATABASE:-app}
+      MARIADB_ROOT_PASSWORD: ${MARIADB_ROOT_PASSWORD:-!ChangeMe!}
+      MARIADB_USER: ${MARIADB_USER:-app}
+      MARIADB_PASSWORD: ${MARIADB_PASSWORD:-!ChangeMe!}
     healthcheck:
-      test: ["CMD", "mysqladmin", "ping", "-h", "localhost"]
+      test: ["CMD", "healthcheck.sh", "--connect", "--innodb_initialized"]
       timeout: 5s
       retries: 5
       start_period: 60s

--- a/app/compose.yaml
+++ b/app/compose.yaml
@@ -1,25 +1,57 @@
 
 services:
+  app:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    container_name: vendhound_app
+    restart: unless-stopped
+    working_dir: /var/www/html
+    volumes:
+      - ./:/var/www/html
+      - /var/www/html/vendor
+    ports:
+      - "8080:80"
+    environment:
+      - APP_ENV=${APP_ENV:-dev}
+      - APP_SECRET=${APP_SECRET:-ChangeThisSecretKey}
+      - DATABASE_URL=mysql://${MYSQL_USER:-app}:${MYSQL_PASSWORD:-!ChangeMe!}@database:3306/${MYSQL_DATABASE:-app}?serverVersion=8.0&charset=utf8mb4
+      - MAILER_DSN=smtp://mailer:1025
+      - EMAIL_FROM_ADDRESS=${EMAIL_FROM_ADDRESS:-noreply@vendhound.local}
+      - EMAIL_FROM_NAME=${EMAIL_FROM_NAME:-VendHound}
+    depends_on:
+      database:
+        condition: service_healthy
+    networks:
+      - vendhound_network
+
 ###> doctrine/doctrine-bundle ###
   database:
-    image: postgres:${POSTGRES_VERSION:-16}-alpine
+    image: mysql:${MYSQL_VERSION:-8.0}
+    container_name: vendhound_db
     environment:
-      POSTGRES_DB: ${POSTGRES_DB:-app}
-      # You should definitely change the password in production
-      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-!ChangeMe!}
-      POSTGRES_USER: ${POSTGRES_USER:-app}
+      MYSQL_DATABASE: ${MYSQL_DATABASE:-app}
+      MYSQL_ROOT_PASSWORD: ${MYSQL_ROOT_PASSWORD:-!ChangeMe!}
+      MYSQL_USER: ${MYSQL_USER:-app}
+      MYSQL_PASSWORD: ${MYSQL_PASSWORD:-!ChangeMe!}
     healthcheck:
-      test: ["CMD", "pg_isready", "-d", "${POSTGRES_DB:-app}", "-U", "${POSTGRES_USER:-app}"]
+      test: ["CMD", "mysqladmin", "ping", "-h", "localhost"]
       timeout: 5s
       retries: 5
       start_period: 60s
     volumes:
-      - database_data:/var/lib/postgresql/data:rw
+      - database_data:/var/lib/mysql:rw
       # You may use a bind-mounted host directory instead, so that it is harder to accidentally remove the volume and lose all your data!
-      # - ./docker/db/data:/var/lib/postgresql/data:rw
+      # - ./docker/db/data:/var/lib/mysql:rw
+    networks:
+      - vendhound_network
 ###< doctrine/doctrine-bundle ###
 
 volumes:
 ###> doctrine/doctrine-bundle ###
   database_data:
 ###< doctrine/doctrine-bundle ###
+
+networks:
+  vendhound_network:
+    driver: bridge

--- a/app/migrations/Version20251004001342.php
+++ b/app/migrations/Version20251004001342.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+final class Version20251004001342 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Add missing columns to dealership and table tables, create table_add_on table';
+    }
+
+    public function up(Schema $schema): void
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->addSql('CREATE TABLE table_add_on (id INT AUTO_INCREMENT NOT NULL, name VARCHAR(255) NOT NULL, description LONGTEXT DEFAULT NULL, additional_cost DOUBLE PRECISION NOT NULL, PRIMARY KEY(id)) DEFAULT CHARACTER SET utf8mb4 COLLATE `utf8mb4_unicode_ci` ENGINE = InnoDB');
+        $this->addSql('ALTER TABLE dealership ADD table_request_type_second_id INT DEFAULT NULL, ADD table_request_type_three_id INT DEFAULT NULL, ADD table_add_on_id INT DEFAULT NULL, ADD email VARCHAR(255) NOT NULL, ADD legalname VARCHAR(255) NOT NULL, ADD phone VARCHAR(255) NOT NULL, ADD website VARCHAR(255) DEFAULT NULL, ADD rating VARCHAR(255) DEFAULT NULL, ADD special_requests LONGTEXT DEFAULT NULL');
+        $this->addSql('ALTER TABLE dealership ADD CONSTRAINT fk_dealership_table_type_second FOREIGN KEY (table_request_type_second_id) REFERENCES table_type (id)');
+        $this->addSql('ALTER TABLE dealership ADD CONSTRAINT fk_dealership_table_type_three FOREIGN KEY (table_request_type_three_id) REFERENCES table_type (id)');
+        $this->addSql('ALTER TABLE dealership ADD CONSTRAINT fk_dealership_table_addon FOREIGN KEY (table_add_on_id) REFERENCES table_add_on (id)');
+        $this->addSql('CREATE INDEX idx_dealership_table_type_second ON dealership (table_request_type_second_id)');
+        $this->addSql('CREATE INDEX idx_dealership_table_type_three ON dealership (table_request_type_three_id)');
+        $this->addSql('CREATE INDEX idx_dealership_table_addon ON dealership (table_add_on_id)');
+        $this->addSql('ALTER TABLE `table` ADD dealership_id INT DEFAULT NULL');
+        $this->addSql('ALTER TABLE `table` ADD CONSTRAINT fk_table_dealership FOREIGN KEY (dealership_id) REFERENCES dealership (id)');
+        $this->addSql('CREATE INDEX idx_table_dealership ON `table` (dealership_id)');
+    }
+
+    public function down(Schema $schema): void
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->addSql('ALTER TABLE dealership DROP FOREIGN KEY FK_7D7A975DA449EEA8');
+        $this->addSql('DROP TABLE table_add_on');
+        $this->addSql('ALTER TABLE dealership DROP FOREIGN KEY FK_7D7A975DCEB02DD5');
+        $this->addSql('ALTER TABLE dealership DROP FOREIGN KEY FK_7D7A975D3F19FBCB');
+        $this->addSql('DROP INDEX IDX_7D7A975DCEB02DD5 ON dealership');
+        $this->addSql('DROP INDEX IDX_7D7A975D3F19FBCB ON dealership');
+        $this->addSql('DROP INDEX IDX_7D7A975DA449EEA8 ON dealership');
+        $this->addSql('ALTER TABLE dealership DROP table_request_type_second_id, DROP table_request_type_three_id, DROP table_add_on_id, DROP email, DROP legalname, DROP phone, DROP website, DROP rating, DROP special_requests');
+        $this->addSql('ALTER TABLE `table` DROP FOREIGN KEY FK_F6298F468CF5FC51');
+        $this->addSql('DROP INDEX IDX_F6298F468CF5FC51 ON `table`');
+        $this->addSql('ALTER TABLE `table` DROP dealership_id');
+    }
+}

--- a/app/public/.htaccess
+++ b/app/public/.htaccess
@@ -1,0 +1,67 @@
+# Use the front controller as index file. It serves as a fallback solution when
+# every other rewrite/redirect fails (e.g. in an aliased environment without
+# mod_rewrite). Additionally, this reduces the matching process for the
+# start page (path "/") because otherwise Apache will apply the rewriting rules
+# to each configured DirectoryIndex file (e.g. index.php, index.html, index.pl).
+DirectoryIndex index.php
+
+# By default, Apache does not evaluate symbolic links if you did not enable this
+# feature in your server configuration. Uncomment the following line if you
+# install assets as symlinks or if you experience problems related to symlinks
+# when compiling LESS/Sass/CoffeScript assets.
+# Options +FollowSymlinks
+
+# Disabling MultiViews prevents unwanted negotiation, e.g. "/index" should not resolve
+# to the front controller "/index.php" but be rewritten to "/index.php/index".
+<IfModule mod_negotiation.c>
+    Options -MultiViews
+</IfModule>
+
+<IfModule mod_rewrite.c>
+    RewriteEngine On
+
+    # Determine the RewriteBase automatically and set it as environment variable.
+    # If you are using Apache aliases to do mass virtual hosting or installed the
+    # project in a subdirectory, the base path will be prepended to allow proper
+    # resolution of the index.php file and to redirect to the correct URI. It will
+    # work in environments without path prefix as well, providing a safe, one-size
+    # fits all solution. But as you do not need it in this case, you can comment
+    # the following 2 lines to eliminate the overhead.
+    RewriteCond %{REQUEST_URI}::$0 ^(/.+)/(.*)::\2$
+    RewriteRule .* - [E=BASE:%1]
+
+    # Sets the HTTP_AUTHORIZATION header removed by Apache
+    RewriteCond %{HTTP:Authorization} .+
+    RewriteRule ^ - [E=HTTP_AUTHORIZATION:%0]
+
+    # Redirect to URI without front controller to prevent duplicate content
+    # (with and without `/index.php`). Only do this redirect on the initial
+    # rewrite by Apache and not on subsequent cycles. Otherwise we would get an
+    # endless redirect loop (request -> rewrite to front controller ->
+    # redirect -> request -> ...).
+    # So in case you get a "too many redirects" error or you always get redirected
+    # to the start page because your Apache does not expose the REDIRECT_STATUS
+    # environment variable, you have 2 choices:
+    # - disable this feature by commenting the following 2 lines or
+    # - use Apache >= 2.3.9 and replace all L flags by END flags and remove the
+    #   following RewriteCond (best solution)
+    RewriteCond %{ENV:REDIRECT_STATUS} =""
+    RewriteRule ^index\.php(?:/(.*)|$) %{ENV:BASE}/$1 [R=301,L]
+
+    # If the requested filename exists, simply serve it.
+    # We only want to let Apache serve files and not directories.
+    # Rewrite all other queries to the front controller.
+    RewriteCond %{REQUEST_FILENAME} !-f
+    RewriteRule ^ %{ENV:BASE}/index.php [L]
+</IfModule>
+
+<IfModule !mod_rewrite.c>
+    <IfModule mod_alias.c>
+        # When mod_rewrite is not available, we instruct a temporary redirect of
+        # the start page to the front controller explicitly so that the website
+        # and the generated links can still be used.
+        RedirectMatch 307 ^/$ /index.php/
+        # RedirectTemp cannot be used instead
+    </IfModule>
+</IfModule>
+


### PR DESCRIPTION
This MR updates the Docker compose and dockerfiles such that a new developer can run the app with one command `docker-compose up -d --build`, without needing to install PHP, Composer, or any other dependencies on their own machine.

It runs the `database`, `mailer`, and `app`, in their own docker containers.

This MR also creates a migration that includes missing fields that are referenced in the code.